### PR TITLE
Various QOL and code changes

### DIFF
--- a/Layout/DEBIAN/control
+++ b/Layout/DEBIAN/control
@@ -1,6 +1,6 @@
 Package: me.renai.panic
 Name: Panic!
-Version: 1.0.1
+Version: 1.0.2
 Architecture: iphoneos-arm
 Description: Stop! Don't panic, you can still fix this...
 Maintainer: Renaitare <support@renai.me>

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,6 @@ include $(THEOS)/makefiles/common.mk
 export ARCHS = arm64 arm64e
 export TARGET = iphone:clang:14.0:11.0
 export ADDITIONAL_CFLAGS = -DTHEOS_LEAN_AND_MEAN
+export PREFIX = $(THEOS)/toolchain/Xcode.xctoolchain/usr/bin/
 
 include $(THEOS_MAKE_PATH)/aggregate.mk

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,5 @@ include $(THEOS)/makefiles/common.mk
 export ARCHS = arm64 arm64e
 export TARGET = iphone:clang:14.0:11.0
 export ADDITIONAL_CFLAGS = -DTHEOS_LEAN_AND_MEAN
-export PREFIX = $(THEOS)/toolchain/Xcode.xctoolchain/usr/bin/
 
 include $(THEOS_MAKE_PATH)/aggregate.mk

--- a/Sources/Plugin/PXHandler.h
+++ b/Sources/Plugin/PXHandler.h
@@ -1,6 +1,13 @@
 #import <Foundation/NSUserDefaults+Domain.h>
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import <spawn.h>
+
+#ifdef DEBUG
+#define NSLog(...) NSLog(__VA_ARGS__)
+#else
+#define NSLog(...) (void)0
+#endif
 
 typedef enum {
 	PXPhysicalButtonTypeVolumeUp = 102,

--- a/Sources/Plugin/PXHandler.m
+++ b/Sources/Plugin/PXHandler.m
@@ -50,16 +50,8 @@
 - (void)respringDevice {
 	if (self.respringEnabled) {
 		pid_t pid;
-		BOOL isDirectory;
-
-		// Check to see if 'sbreload' exists, otherwise just respring via 'killall'
-		if ([[NSFileManager defaultManager] fileExistsAtPath:@"/usr/bin/sbreload" isDirectory:&isDirectory]) {
-			const char* args[] = {"sbreload", NULL};
-			posix_spawn(&pid, "/usr/bin/sbreload", NULL, NULL, (char* const*)args, NULL);
-		} else {
-			const char* args[] = {"killall", "SpringBoard", NULL};
-			posix_spawn(&pid, "/usr/bin/killall", NULL, NULL, (char* const*)args, NULL);
-		}
+		const char* args[] = {"sbreload", NULL};
+		posix_spawnp(&pid, "sbreload", NULL, NULL, (char* const*)args, NULL);
 	}
 }
 
@@ -67,7 +59,7 @@
 	if (self.safemodeEnabled) {
 		pid_t pid;
 		const char* args[] = {"killall", "-SEGV", "SpringBoard", NULL};
-		posix_spawn(&pid, "/usr/bin/killall", NULL, NULL, (char* const*)args, NULL);
+		posix_spawnp(&pid, "killall", NULL, NULL, (char* const*)args, NULL);
 	}
 }
 

--- a/Sources/Plugin/Panic.plist
+++ b/Sources/Plugin/Panic.plist
@@ -1,1 +1,7 @@
-{ Filter = { Bundles = ( "com.apple.springboard" ); }; }
+{
+    Filter = {
+        Bundles = (
+            "com.apple.springboard",
+        );
+    };
+}

--- a/Sources/Plugin/Tweak.x
+++ b/Sources/Plugin/Tweak.x
@@ -1,4 +1,3 @@
-#import <UIKit/UIKit.h>
 #import "PXHandler.h"
 
 %hook SpringBoard
@@ -37,5 +36,5 @@ static void notificationCallback(CFNotificationCenterRef center, void *observer,
 
 %ctor {
 	notificationCallback(NULL, NULL, NULL, NULL, NULL);
-	CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL, notificationCallback, CFSTR("me.renai.panic/options.update"), NULL, CFNotificationSuspensionBehaviorCoalesce);
+	CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(), NULL, notificationCallback, CFSTR("me.renai.panic/settings.update"), NULL, CFNotificationSuspensionBehaviorCoalesce);
 }

--- a/Sources/Settings/Resources/Root.plist
+++ b/Sources/Settings/Resources/Root.plist
@@ -42,7 +42,7 @@
 				<key>label</key>
 				<string>Safemode Enabled</string>
 				<key>PostNotification</key>
-				<string>me.renai.panic/options.update</string>
+				<string>me.renai.panic/settings.update</string>
 			</dict>
 			<dict>
 				<key>cell</key>
@@ -56,7 +56,7 @@
 				<key>label</key>
 				<string>Respring Enabled</string>
 				<key>PostNotification</key>
-				<string>me.renai.panic/options.update</string>
+				<string>me.renai.panic/settings.update</string>
 			</dict>
 			<dict>
 				<key>cell</key>
@@ -68,7 +68,7 @@
 				<key>key</key>
 				<string>safemode_sequence</string>
 				<key>PostNotification</key>
-				<string>me.renai.panic/options.update</string>
+				<string>me.renai.panic/settings.update</string>
 				<key>label</key>
 				<string>Safemode Sequence</string>
 				<key>isController</key>
@@ -84,7 +84,7 @@
 				<key>key</key>
 				<string>respring_sequence</string>
 				<key>PostNotification</key>
-				<string>me.renai.panic/options.update</string>
+				<string>me.renai.panic/settings.update</string>
 				<key>label</key>
 				<string>Respring Sequence</string>
 				<key>isController</key>


### PR DESCRIPTION
Mostly formatting changes.

Real code changes: Remove the `killall`/`sbreload` difference/availability check. `UIKitTools` is present in every iOS 11-present jailbreak and `sbreload` is guaranteed to exist. Switched to `posix_spawnp` in case the binary was moved. This will find it automatically instead of needing a full path. Changed `me.renai.panic/options.update` to `me.renai.panic/settings.update` for project uniformity.